### PR TITLE
Remove data mutation from write_point

### DIFF
--- a/lib/influxdb/query/core.rb
+++ b/lib/influxdb/query/core.rb
@@ -46,8 +46,7 @@ module InfluxDB
       # Example:
       # write_point('cpu', tags: {region: 'us'}, values: {internal: 60})
       def write_point(series, data, precision = nil)
-        data.merge!(series: series)
-        write_points(data, precision)
+        write_points(data.merge(series: series), precision)
       end
 
       def write(data, precision)

--- a/spec/influxdb/cases/write_points_spec.rb
+++ b/spec/influxdb/cases/write_points_spec.rb
@@ -40,6 +40,13 @@ describe InfluxDB::Client do
     it "should POST to add single point" do
       expect(subject.write_point(series, data)).to be_a(Net::HTTPOK)
     end
+
+    it "should not mutate data object" do
+      original_data = data
+      subject.write_point(series, data)
+      expect(data[:series]).to be_nil
+      expect(original_data).to eql(data)
+    end
   end
 
   describe "#write_points" do


### PR DESCRIPTION
Currently using write_point unexpectedly (and unnecessarily)
mutates the data object passed to the method
